### PR TITLE
Compatibility with Dsdata_NoState

### DIFF
--- a/app/code/community/Netzarbeiter/CustomerActivation/Model/Observer.php
+++ b/app/code/community/Netzarbeiter/CustomerActivation/Model/Observer.php
@@ -379,7 +379,7 @@ class Netzarbeiter_CustomerActivation_Model_Observer
      *
      * @param Mage_Adminhtml_Block_Customer_Grid $block
      */
-    protected function _addActivationStatusColumn(Mage_Adminhtml_Block_Customer_Grid $block)
+    protected function _addActivationStatusColumn(Mage_Adminhtml_Block_Widget_Grid $block)
     {
         /** @var $helper Netzarbeiter_CustomerActivation_Helper_Data */
         $helper = Mage::helper('customeractivation');


### PR DESCRIPTION
https://github.com/dsdata/NoState uses Mage_Adminhtml_Block_Widget_Grid and reimplements most of the code from Mage_Adminhtml_Block_Customer_Grid.

See https://github.com/dsdata/NoState/blob/master/app/code/community/Dsdata/NoState/Block/Customer/Grid.php for their reasoning.

On a side note, type hinting in magento seems to be pointless due to the custom error handler in app/code/core/Mage/Core/functions.php. When developer mode is not activated no exceptions are thrown and execution continues, effectively disabling type hinting.
