### PR TITLE
Add support for large customer database to upgrade script

### DIFF
--- a/app/code/community/Netzarbeiter/CustomerActivation/sql/customeractivation_setup/mysql4-upgrade-0.2.8-0.2.9.php
+++ b/app/code/community/Netzarbeiter/CustomerActivation/sql/customeractivation_setup/mysql4-upgrade-0.2.8-0.2.9.php
@@ -24,12 +24,12 @@ $installer->startSetup();
 
 $resource = Mage::getResourceModel('customer/customer');
 
-// Set activation status for existing customers to true
-$select = $installer->getConnection()->select()
-    ->from($resource->getEntityTable(), $resource->getEntityIdField());
-$customerIds = $installer->getConnection()->fetchCol($select);
-
-$updatedCustomerIds = Mage::getResourceModel('customeractivation/customer')
-    ->massSetActivationStatus($customerIds, 1);
+$ids = array();
+foreach (Mage::getModel('customer/customer')->getCollection() as $_customer) { 
+    $ids[] = $_customer->getEntityId();
+}
+foreach (array_chunk($ids,1000) as $updateIds) {
+    $updatedCustomerIds = Mage::getResourceModel('customeractivation/customer')->massSetActivationStatus($updateIds, 1);
+}
 
 $installer->endSetup();


### PR DESCRIPTION
We kept running out of memory when trying to apply this upgrade script to a 250,000 customer site.  This fix will get the customer Id's from the magento customer collection and then activate them 1000 at a time.