### PR TITLE
Fix upgrade script to allow large customer database

### DIFF
--- a/app/code/community/Netzarbeiter/CustomerActivation/sql/customeractivation_setup/mysql4-upgrade-0.2.8-0.2.9.php
+++ b/app/code/community/Netzarbeiter/CustomerActivation/sql/customeractivation_setup/mysql4-upgrade-0.2.8-0.2.9.php
@@ -29,7 +29,8 @@ $select = $installer->getConnection()->select()
     ->from($resource->getEntityTable(), $resource->getEntityIdField());
 $customerIds = $installer->getConnection()->fetchCol($select);
 
-$updatedCustomerIds = Mage::getResourceModel('customeractivation/customer')
-    ->massSetActivationStatus($customerIds, 1);
+foreach (array_chunk($customerIds,1000) as $updateIds) {
+    $updatedCustomerIds = Mage::getResourceModel('customeractivation/customer')->massSetActivationStatus($updateIds, 1);
+}
 
 $installer->endSetup();


### PR DESCRIPTION
We kept running out of memory when trying to apply this upgrade script to a 250,000 customer site. This fix will activate customers 1000 at a time.

This PR is a cleaner version of https://github.com/Vinai/customer-activation/pull/77