### PR TITLE
Explicitly load the customer address from the database for new customers

### DIFF
--- a/app/code/community/Netzarbeiter/CustomerActivation/Helper/Data.php
+++ b/app/code/community/Netzarbeiter/CustomerActivation/Helper/Data.php
@@ -129,8 +129,8 @@ class Netzarbeiter_CustomerActivation_Helper_Data extends Mage_Core_Helper_Abstr
                     $recipient['name'],
                     array(
                         'customer' => $customer,
-                        'shipping' => $customer->getPrimaryShippingAddress(),
-                        'billing' => $customer->getPrimaryBillingAddress(),
+                        'shipping' => $customer->getAddressById($customer->getDefaultShipping()),
+                        'billing' => $customer->getAddressById($customer->getDefaultBilling()),
                         'store' => Mage::app()->getStore(
                             // In case of admin store emails, $storeId is set to 0.
                             // We want 'store' to always be set to the customers store.


### PR DESCRIPTION
Funny how apparently nobody noticed this before.  At the moment that the customer activation mail gets sent, the customer object has just been saved.  The attributes 'default_billing' and 'default_shipping' are already filled, but the address is not yet loaded in the customer object's addresses collection. So a call to `$customer->getPrimaryBillingAddress()` will not return the default billing address of the customer, but instead return `false`.

The solution is to load the address explicitly from the database before passing it to the mail sending method.